### PR TITLE
Rename task to be riprap not matomo

### DIFF
--- a/tasks/apache_config.yml
+++ b/tasks/apache_config.yml
@@ -20,7 +20,7 @@
     owner: "{{ webserver_app_user }}"
     group: "{{ webserver_app_user }}"
 
-- name: Symlink matomo httpd config file into action
+- name: Symlink riprap httpd config file into action
   file:
     src: "{{httpd_conf_directory}}/conf-available/riprap.conf"
     dest: "{{httpd_conf_directory_enabled}}/riprap.conf"


### PR DESCRIPTION
Typo?
Will this affect anything outside of this repo? (this is the only place in this role that the word matomo exists)